### PR TITLE
Fix compiling instructions and makefile bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,9 +220,17 @@ all: deps no-deps
 #---------------------------------------------------------------------------------
 deps:
 	@mkdir -p $(BUILD) $(GFXBUILD) $(OUTDIR)
+ifeq ($(OS),Windows_NT)
 	@cd $(BUILD)/$(PACKER) && py -3 packer.py
+else
+	@cd $(BUILD)/$(PACKER) && python3 packer.py
+endif
 	@cd $(BUILD)/$(PACKER) && mv out/*.bin out/*.json ../../assets/romfs/mg
+ifeq ($(OS),Windows_NT)
 	@cd $(BUILD)/$(SCRIPTS) && py -3 genScripts.py
+else
+	@cd $(BUILD)/$(SCRIPTS) && python3 genScripts.py
+endif
 	@rm -fr assets/romfs/scripts
 	@cd $(BUILD)/$(SCRIPTS) && mv -f scripts ../../assets/romfs
 #---------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ You can get real-time support by joining PKSM's discord server.
 
 ## Building
 
-PKSM requires [latest libctru](https://github.com/smealum/ctrulib), [latest citro3d](https://github.com/fincs/citro3d) and [latest pp2d](https://github.com/BernardoGiordano/PKSM/tree/master/source/pp2d). The executable can be compiled with [devkitARM r47+](https://sourceforge.net/projects/devkitpro/).To compile the .cia you need [3dstool](https://github.com/dnasdw/3dstool/releases), [bannertool and makerom](https://github.com/Steveice10/buildtools/tree/master/3ds) in your PATH. Run the command `make all` to build both the .3dsx and .cia.
+PKSM has the following dependencies:
+
+- The latest version of ctrulib, citro3d, citro2d, 3ds-curl and [3dstool](https://github.com/dnasdw/3dstool/releases), [bannertool](https://github.com/Steveice10/bannertool/releases) and [makerom](https://github.com/profi200/Project_CTR/releases). (All of these except for bannertool, makerom and 3dstool should be installed from the [devKitPro pacman repository](https://devkitpro.org/wiki/devkitPro_pacman. ctrulib, citro3d and citro2d should be installed with `3ds-dev` and then selecting yes on the entire group instead of installing the packages directly).
+- The latest version of python 3.x and the GitPython library.
+
+To compile, clone the repository with all submodules (`git clone --recursive https://github.com/FlagBrew/PKSM.git` if initially cloning, `git submodule init` and `git submodule update` if running from an existing clone) and run `make all`.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can get real-time support by joining PKSM's discord server.
 
 PKSM has the following dependencies:
 
-- The latest version of ctrulib, citro3d, citro2d, 3ds-curl and [3dstool](https://github.com/dnasdw/3dstool/releases), [bannertool](https://github.com/Steveice10/bannertool/releases) and [makerom](https://github.com/profi200/Project_CTR/releases). (All of these except for bannertool, makerom and 3dstool should be installed from the [devKitPro pacman repository](https://devkitpro.org/wiki/devkitPro_pacman. ctrulib, citro3d and citro2d should be installed with `3ds-dev` and then selecting yes on the entire group instead of installing the packages directly).
+- The latest version of ctrulib, citro3d, citro2d, 3ds-curl and [3dstool](https://github.com/dnasdw/3dstool/releases), [bannertool](https://github.com/Steveice10/bannertool/releases) and [makerom](https://github.com/profi200/Project_CTR/releases). (All of these except for bannertool, makerom and 3dstool should be installed from the [devKitPro pacman repository](https://devkitpro.org/wiki/devkitPro_pacman). ctrulib, citro3d and citro2d should be installed with `3ds-dev` and then selecting yes on the entire group instead of installing the packages directly).
 - The latest version of python 3.x and the GitPython library.
 
 To compile, clone the repository with all submodules (`git clone --recursive https://github.com/FlagBrew/PKSM.git` if initially cloning, `git submodule init` and `git submodule update` if running from an existing clone) and run `make all`.


### PR DESCRIPTION
This updates the compiling instructions in the README to accomodate for citro2d, devkitPro-pacman and the scripts folder.

Also fixed a minor mistake in the Makefile that would cause it to be non-functional on non-windows systems.