### PR TITLE
Allow using ZR/ZL to change storage box

### DIFF
--- a/include/gui/screen/StorageScreen.hpp
+++ b/include/gui/screen/StorageScreen.hpp
@@ -56,6 +56,8 @@ private:
     // Have to basically reimplement Hid because two Hids don't go well together
     bool lastBox(bool forceBottom = false);
     bool nextBox(bool forceBottom = false);
+    bool prevBoxTop(bool forceBottom = false);
+    bool nextBoxTop(bool forceBottom = false);
     bool clickBottomIndex(int index);
     void setBoxName(bool storage);
     void pickup();

--- a/include/gui/screen/StorageScreen.hpp
+++ b/include/gui/screen/StorageScreen.hpp
@@ -56,8 +56,8 @@ private:
     // Have to basically reimplement Hid because two Hids don't go well together
     bool lastBox(bool forceBottom = false);
     bool nextBox(bool forceBottom = false);
-    bool prevBoxTop(bool forceBottom = false);
-    bool nextBoxTop(bool forceBottom = false);
+    bool prevBoxTop();
+    bool nextBoxTop();
     bool clickBottomIndex(int index);
     void setBoxName(bool storage);
     void pickup();

--- a/source/gui/screen/StorageScreen.cpp
+++ b/source/gui/screen/StorageScreen.cpp
@@ -608,39 +608,21 @@ void StorageScreen::update(touchPosition* touch)
                 sleep = true;
             }
             
-            else if (kHeld & KEY_ZR & !forcebottom)
+            else if (kHeld & KEY_ZR)
             
             {
             	
-               storageBox++;
-
-               if (storageBox == Configuration::getInstance().storageSize())
-
-               {
-
-                  storageBox = 0;
-                
-               }
-
-       		 sleep = true;
+               nextBoxTop();
+               sleep = true;
 
             }
             
-            else if (kHeld & KEY_ZL & !forcebottom)
+            else if (kHeld & KEY_ZL)
             
             {
             	
-               storageBox--;
-
-               if (storageBox == -1)
-
-               {
-		
-                  storageBox = Configuration::getInstance().storageSize() - 1;
-
-               }
-	
-				sleep = true;
+               lastBoxTop();
+               sleep = true;
 
             }
 
@@ -685,6 +667,19 @@ bool StorageScreen::lastBox(bool forceBottom)
     return false;
 }
 
+bool StorageScreen::lastBoxTop(bool forceBottom)
+{
+    if (!forceBottom)
+    {
+        storageBox--;
+        if (storageBox == -1)
+        {
+            storageBox = Configuration::getInstance().storageSize() - 1;
+        }
+    }
+    return false;
+}
+
 bool StorageScreen::nextBox(bool forceBottom)
 {
     if (storageChosen && !forceBottom)
@@ -701,6 +696,19 @@ bool StorageScreen::nextBox(bool forceBottom)
         if (boxBox == TitleLoader::save->maxBoxes())
         {
             boxBox = 0;
+        }
+    }
+    return false;
+}
+
+bool StorageScreen::nextBoxTop(bool forceBottom)
+{
+    if (!forceBottom)
+    {
+        storageBox++;
+        if (storageBox == Configuration::getInstance().storageSize())
+        {
+            storageBox = 0;
         }
     }
     return false;

--- a/source/gui/screen/StorageScreen.cpp
+++ b/source/gui/screen/StorageScreen.cpp
@@ -667,15 +667,12 @@ bool StorageScreen::lastBox(bool forceBottom)
     return false;
 }
 
-bool StorageScreen::prevBoxTop(bool forceBottom)
+bool StorageScreen::prevBoxTop()
 {
-    if (!forceBottom)
+    storageBox--;
+    if (storageBox == -1)
     {
-        storageBox--;
-        if (storageBox == -1)
-        {
-            storageBox = Configuration::getInstance().storageSize() - 1;
-        }
+        storageBox = Configuration::getInstance().storageSize() - 1;
     }
     return false;
 }
@@ -701,15 +698,12 @@ bool StorageScreen::nextBox(bool forceBottom)
     return false;
 }
 
-bool StorageScreen::nextBoxTop(bool forceBottom)
+bool StorageScreen::nextBoxTop()
 {
-    if (!forceBottom)
+    storageBox++;
+    if (storageBox == Configuration::getInstance().storageSize())
     {
-        storageBox++;
-        if (storageBox == Configuration::getInstance().storageSize())
-        {
-            storageBox = 0;
-        }
+        storageBox = 0;
     }
     return false;
 }

--- a/source/gui/screen/StorageScreen.cpp
+++ b/source/gui/screen/StorageScreen.cpp
@@ -621,7 +621,7 @@ void StorageScreen::update(touchPosition* touch)
             
             {
             	
-               lastBoxTop();
+               prevBoxTop();
                sleep = true;
 
             }
@@ -667,7 +667,7 @@ bool StorageScreen::lastBox(bool forceBottom)
     return false;
 }
 
-bool StorageScreen::lastBoxTop(bool forceBottom)
+bool StorageScreen::prevBoxTop(bool forceBottom)
 {
     if (!forceBottom)
     {

--- a/source/gui/screen/StorageScreen.cpp
+++ b/source/gui/screen/StorageScreen.cpp
@@ -607,6 +607,42 @@ void StorageScreen::update(touchPosition* touch)
                 lastBox();
                 sleep = true;
             }
+            
+            else if (kHeld & KEY_ZR & !forcebottom)
+            
+            {
+            	
+               storageBox++;
+
+               if (storageBox == Configuration::getInstance().storageSize())
+
+               {
+
+                  storageBox = 0;
+                
+               }
+
+       		 sleep = true;
+
+            }
+            
+            else if (kHeld & KEY_ZL & !forcebottom)
+            
+            {
+            	
+               storageBox--;
+
+               if (storageBox == -1)
+
+               {
+		
+                  storageBox = Configuration::getInstance().storageSize() - 1;
+
+               }
+	
+				sleep = true;
+
+            }
 
             if (sleep)
                 buttonCooldown = 10;


### PR DESCRIPTION
This should allow the user to change storage boxes regardless of where the cursor is using ZR and ZL buttons on N3DS. 
It has not been tested yet, as I can't build PKSM currently.