### PR TITLE
Be more permissive of looparound EV controls

### DIFF
--- a/3ds/source/gui/screen/EditorScreen.cpp
+++ b/3ds/source/gui/screen/EditorScreen.cpp
@@ -810,7 +810,7 @@ bool EditorScreen::changeSecondaryStat(int which, bool up)
                 total += pkm->ev(i);
             }
             // TODO: remove hardcoded value and set it in classes
-            if (total < 510)
+            if (total < 510 || pkm->ev(which) == 0xFC)
             {
                 if (pkm->ev(which) < 0xFC)
                 {
@@ -851,7 +851,7 @@ bool EditorScreen::changeSecondaryStat(int which, bool up)
                     total += pkm->ev(i);
                 }
                 // TODO: remove hardcoded value and set it in classes
-                if (total < 510)
+                if (total <= 510)
                 {
                     pkm->ev(which, 0xFC);
                 }   


### PR DESCRIPTION
- "+" button to change from 252 EV to 0 should work even if the current global budget is right up against the 510 limit, instead of only working at 509 or less

- "-" button to change from 0 EV to 252 should work if the others add to 258 or less, not just 257 or less