### PR TITLE
Set OT gender when creating a Pokémon using save info

### DIFF
--- a/3ds/source/gui/screen/EditorScreen.cpp
+++ b/3ds/source/gui/screen/EditorScreen.cpp
@@ -60,6 +60,7 @@ EditorScreen::EditorScreen(std::shared_ptr<PKX> pokemon, int box, int index, boo
             pkm->TID(TitleLoader::save->TID());
             pkm->SID(TitleLoader::save->SID());
             pkm->otName(TitleLoader::save->otName());
+            pkm->otGender(TitleLoader::save->gender());
         }
         else
         {


### PR DESCRIPTION
This makes it so when a Pokémon is created and PKSM is set to use the save file's info the Pokémon will have the OT's gender from the save, I think if this isn't set correctly the Pokémon wouldn't obey the trainer so it's nice to have it right without needing to click the set to self button.

I tested a build of this on my n3DS and it was setting the OT gender correctly