### PR TITLE
Add save_path script method

### DIFF
--- a/3ds/include/titles/loader.hpp
+++ b/3ds/include/titles/loader.hpp
@@ -56,6 +56,7 @@ namespace TitleLoader
     void saveToTitle(bool ask);
     void init(void);
     void exit(void);
+    std::string savePath(void);
 
     // Title list
     inline std::vector<std::shared_ptr<Title>> nandTitles;

--- a/3ds/source/picoc/pksm_api.cpp
+++ b/3ds/source/picoc/pksm_api.cpp
@@ -294,6 +294,19 @@ void delete_directory(struct ParseState* Parser, struct Value* ReturnValue, stru
     }
 }
 
+void save_path(struct ParseState* Parser, struct Value* ReturnValue, struct Value** Param, int numArgs)
+{
+    auto savePath = TitleLoader::savePath();
+    if (savePath.empty())
+    {
+        ReturnValue->Val->Pointer = nullptr;
+    }
+    else
+    {
+        ReturnValue->Val->Pointer = strToRet(TitleLoader::savePath());
+    }
+}
+
 void sav_inject_pkx(struct ParseState* Parser, struct Value* ReturnValue, struct Value** Param, int NumArgs)
 {
     u8* data          = (u8*)Param[0]->Val->Pointer;

--- a/3ds/source/titles/loader.cpp
+++ b/3ds/source/titles/loader.cpp
@@ -612,6 +612,16 @@ void TitleLoader::saveChanges()
     save->beginEditing();
 }
 
+std::string TitleLoader::savePath()
+{
+    std::string savePath;
+    if (saveIsFile)
+    {
+        savePath = saveFileName;
+    }
+    return savePath;
+}
+
 void TitleLoader::exit()
 {
     continueScan.clear();

--- a/3ds/source/titles/loader.cpp
+++ b/3ds/source/titles/loader.cpp
@@ -614,12 +614,11 @@ void TitleLoader::saveChanges()
 
 std::string TitleLoader::savePath()
 {
-    std::string savePath;
     if (saveIsFile)
     {
-        savePath = saveFileName;
+        return savePath;
     }
-    return savePath;
+    return "";
 }
 
 void TitleLoader::exit()

--- a/common/include/picoc/pksm_api.h
+++ b/common/include/picoc/pksm_api.h
@@ -156,6 +156,7 @@ void sav_check_value(struct ParseState*, struct Value*, struct Value**, int);
 void current_directory(struct ParseState*, struct Value*, struct Value**, int);
 void read_directory(struct ParseState*, struct Value*, struct Value**, int);
 void delete_directory(struct ParseState*, struct Value*, struct Value**, int);
+void save_path(struct ParseState*, struct Value*, struct Value**, int);
 void i18n_species(struct ParseState*, struct Value*, struct Value**, int);
 void pkx_decrypt(struct ParseState*, struct Value*, struct Value**, int);
 void pkx_encrypt(struct ParseState*, struct Value*, struct Value**, int);

--- a/common/source/picoc/cstdlib/unistd.c
+++ b/common/source/picoc/cstdlib/unistd.c
@@ -271,6 +271,11 @@ void UnistdRmdir(struct ParseState* Parser, struct Value* ReturnValue, struct Va
     ReturnValue->Val->Integer = rmdir(Param[0]->Val->Pointer);
 }
 
+void UnistdMkdir(struct ParseState* Parser, struct Value* ReturnValue, struct Value** Param, int NumArgs)
+{
+    ReturnValue->Val->Integer = mkdir(Param[0]->Val->Pointer, Param[1]->Val->Integer);
+}
+
 void UnistdSbrk(struct ParseState* Parser, struct Value* ReturnValue, struct Value** Param, int NumArgs)
 {
     ReturnValue->Val->Pointer = sbrk(Param[0]->Val->Integer);
@@ -400,6 +405,7 @@ typedef int size_t; \
 typedef int ssize_t; \
 typedef int useconds_t;\
 typedef int intptr_t;\
+typedef int mode_t;\
 ";
 
 /* all unistd.h functions */
@@ -459,7 +465,7 @@ struct LibraryFunction UnistdFunctions[] = {{UnistdAccess, "int access(char *, i
     /*    { UnistdPwrite,        "ssize_t pwrite(int, void *, size_t, off_t);" }, */
     {UnistdRead, "ssize_t read(int, void *, size_t);"},
     /*    { UnistdReadlink,      "int readlink(char *, char *, size_t);" }, */
-    {UnistdRmdir, "int rmdir(char *);"}, {UnistdSbrk, "void *sbrk(intptr_t);"},
+    {UnistdRmdir, "int rmdir(char *);"}, {UnistdMkdir, "int mkdir(char *, mode_t);"}, {UnistdSbrk, "void *sbrk(intptr_t);"},
     /*    { UnistdSetgid,        "int setgid(gid_t);" }, */
     /*    { UnistdSetpgid,       "int setpgid(pid_t, pid_t);" }, */
     /*    { UnistdSetpgrp,       "pid_t setpgrp(void);" }, */

--- a/common/source/picoc/library_pksm.c
+++ b/common/source/picoc/library_pksm.c
@@ -49,6 +49,7 @@ struct LibraryFunction UnixFunctions[] =
     { current_directory,    "char* current_directory();" },
     { read_directory,       "struct directory* read_directory(char* dir);" },
     { delete_directory,     "void delete_directory(struct directory* dir);" },
+    { save_path,            "char* save_path();" },
     // configurations
     { cfg_default_ot,       "char* cfg_default_ot(enum Generation gen);" },
     { cfg_default_tid,      "unsigned short cfg_default_tid(enum Generation gen);" },


### PR DESCRIPTION
Add a method that gets the path to the save file on the SD card.  This is needed if writing content outside of the save that references the save file.