### PR TITLE
Fix typo in one of the dependencies in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can get real-time support by joining FlagBrew's discord server.
 
 PKSM has the following dependencies:
 
-- The latest version of ctrulib, citro3d, citro2d, 3ds-curl, 3ds-pkg-config, 3ds-bzip2, 3ds-mpg123, 3dstools, and tex3ds with
+- The latest version of libctru, citro3d, citro2d, 3ds-curl, 3ds-pkg-config, 3ds-bzip2, 3ds-mpg123, 3dstools, and tex3ds with
   their dependancies. All of these should be installed from [devKitPro
   pacman](https://devkitpro.org/wiki/devkitPro_pacman).
 - Your system's pkg-config


### PR DESCRIPTION
The dependency is called 'libctru' not 'ctrulib'.